### PR TITLE
Automatic commit of package [lustre-client-build-macros] minor release     [1-6].

### DIFF
--- a/.tito/packages/lustre-client-build-macros
+++ b/.tito/packages/lustre-client-build-macros
@@ -1,1 +1,1 @@
-1-5 lustre-client-build-macros/
+1-6 lustre-client-build-macros/

--- a/.tito/packages/lustre-client-build-macros
+++ b/.tito/packages/lustre-client-build-macros
@@ -1,1 +1,1 @@
-1-4 lustre-client-build-macros/
+1-5 lustre-client-build-macros/

--- a/lustre-client-build-macros/lustre-client-build-macros.spec
+++ b/lustre-client-build-macros/lustre-client-build-macros.spec
@@ -1,6 +1,6 @@
 Name:		lustre-client-build-macros
 Version:	1
-Release:	4%{?dist}
+Release:	5%{?dist}
 Summary:	RPM macros to build a Lustre client SRPM
 
 License:	MIT
@@ -20,7 +20,7 @@ set -x
 mkdir -p %{buildroot}/%{_rpmconfigdir}/macros.d/
 #echo "%kver 3.10.0-514.26.1.el7.x86_64" > %{buildroot}/%{_rpmconfigdir}/macros.d/macros.lustre-client-build
 cat <<EOF > %{buildroot}/%{_rpmconfigdir}/macros.d/macros.lustre-client-build
-%%kver 3.10.0-514.26.1.el7.x86_64
+%%kdir /usr/src/kernels/%%(ls /usr/src/kernels/ | tail -1)
 %%_with_servers 0
 %%_without_servers 1
 EOF
@@ -29,6 +29,11 @@ EOF
 %{_rpmconfigdir}/macros.d/macros.lustre-client-build
 
 %changelog
+* Fri Jun 30 2017 Brian J. Murrell <brian.murrell@intel.com> 1-5
+- better automatically detect the %%kdir
+  - using %%kver requires the kernel RPM to also be installed which
+    shouldn't strictly be necessary
+
 * Fri Jun 30 2017 Brian J. Murrell <brian.murrell@intel.com> 1-4
 - new package built with tito
 - undefine servers macros 

--- a/lustre-client-build-macros/lustre-client-build-macros.spec
+++ b/lustre-client-build-macros/lustre-client-build-macros.spec
@@ -1,6 +1,6 @@
 Name:		lustre-client-build-macros
 Version:	1
-Release:	5%{?dist}
+Release:	6%{?dist}
 Summary:	RPM macros to build a Lustre client SRPM
 
 License:	MIT
@@ -21,7 +21,6 @@ mkdir -p %{buildroot}/%{_rpmconfigdir}/macros.d/
 #echo "%kver 3.10.0-514.26.1.el7.x86_64" > %{buildroot}/%{_rpmconfigdir}/macros.d/macros.lustre-client-build
 cat <<EOF > %{buildroot}/%{_rpmconfigdir}/macros.d/macros.lustre-client-build
 %%kdir /usr/src/kernels/%%(ls /usr/src/kernels/ | tail -1)
-%%_with_servers 0
 %%_without_servers 1
 EOF
 
@@ -29,6 +28,9 @@ EOF
 %{_rpmconfigdir}/macros.d/macros.lustre-client-build
 
 %changelog
+* Fri Jun 30 2017 Brian J. Murrell <brian.murrell@intel.com> 1-6
+- don't need the "%%_with_servers 0"
+
 * Fri Jun 30 2017 Brian J. Murrell <brian.murrell@intel.com> 1-5
 - better automatically detect the %%kdir
   - using %%kver requires the kernel RPM to also be installed which
@@ -37,6 +39,7 @@ EOF
 * Fri Jun 30 2017 Brian J. Murrell <brian.murrell@intel.com> 1-4
 - new package built with tito
 - undefine servers macros 
+
 * Fri Jun 30 2017 Brian J. Murrell <brian.murrell@intel.com> 1-3
 - don't define as a global
 


### PR DESCRIPTION
Created by command:

    /usr/bin/tito tag