### PR TITLE
Add Online Help as a dependency

### DIFF
--- a/.tito/packages/iml-online-help
+++ b/.tito/packages/iml-online-help
@@ -1,0 +1,1 @@
+2.0.3-1 iml-online-help/

--- a/iml-online-help/iml-online-help.spec
+++ b/iml-online-help/iml-online-help.spec
@@ -1,6 +1,6 @@
 %define base_name online-help
 Name:       iml-%{base_name}
-Version:    2.0.2
+Version:    2.0.3
 Release:    1%{?dist}
 Summary:    IML Online Help
 License:    MIT
@@ -32,5 +32,5 @@ rm -rf %{buildroot}
 /usr/lib/iml-manager/%{name}
 
 %changelog
-* Mon Aug 07 2017 Will Johnson <william.c.johnson@intel.com> - 2.0.2-1
+* Mon Aug 07 2017 Will Johnson <william.c.johnson@intel.com> - 2.0.3-1
 - Initial package

--- a/iml-online-help/iml-online-help.spec
+++ b/iml-online-help/iml-online-help.spec
@@ -1,6 +1,6 @@
 %define base_name online-help
 Name:       iml-%{base_name}
-Version:    2.0.0
+Version:    2.0.1
 Release:    1%{?dist}
 Summary:    IML Online Help
 License:    MIT
@@ -32,5 +32,5 @@ rm -rf %{buildroot}
 /usr/lib/iml-manager/%{name}
 
 %changelog
-* Mon Aug 07 2017 Will Johnson <william.c.johnson@intel.com> - 2.0.0-1
+* Mon Aug 07 2017 Will Johnson <william.c.johnson@intel.com> - 2.0.1-1
 - Initial package

--- a/iml-online-help/iml-online-help.spec
+++ b/iml-online-help/iml-online-help.spec
@@ -1,6 +1,6 @@
 %define base_name online-help
 Name:       iml-%{base_name}
-Version:    2.0.1
+Version:    2.0.2
 Release:    1%{?dist}
 Summary:    IML Online Help
 License:    MIT
@@ -32,5 +32,5 @@ rm -rf %{buildroot}
 /usr/lib/iml-manager/%{name}
 
 %changelog
-* Mon Aug 07 2017 Will Johnson <william.c.johnson@intel.com> - 2.0.1-1
+* Mon Aug 07 2017 Will Johnson <william.c.johnson@intel.com> - 2.0.2-1
 - Initial package

--- a/iml-online-help/iml-online-help.spec
+++ b/iml-online-help/iml-online-help.spec
@@ -1,0 +1,36 @@
+%define base_name online-help
+Name:       iml-%{base_name}
+Version:    2.0.0
+Release:    1%{?dist}
+Summary:    IML Online Help
+License:    MIT
+Group:      System Environment/Libraries
+URL:        https://github.com/intel-hpdd/%{base_name}
+Source0:    http://registry.npmjs.org/@iml/%{base_name}/-/%{base_name}-%{version}.tgz
+
+BuildArch:  noarch
+
+%description
+This module is a static html website based on the online-help markdown docs. The html is generated using jekyll.
+
+%prep
+%setup -q -n package
+
+%build
+#nothing to do
+
+%install
+rm -rf %{buildroot}
+
+mkdir -p $RPM_BUILD_ROOT/usr/lib/iml-manager/%{name}
+cp -a dist/. $RPM_BUILD_ROOT/usr/lib/iml-manager/%{name}/
+
+%clean
+rm -rf %{buildroot}
+
+%files 
+/usr/lib/iml-manager/%{name}
+
+%changelog
+* Mon Aug 07 2017 Will Johnson <william.c.johnson@intel.com> - 2.0.0-1
+- Initial package


### PR DESCRIPTION
Now that we've generated online-help using jekyll, we can push it out as
a dependency similar to iml-gui.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>