### PR TITLE
Patch fence_vbox

### DIFF
--- a/fence-agents-vbox/fence-agents-4.0.24.patch
+++ b/fence-agents-vbox/fence-agents-4.0.24.patch
@@ -1,0 +1,13 @@
+Only in fence-agents-4.0.24: .vscode
+diff -ru fence-agents-4.0.24-orig/fence/agents/vbox/fence_vbox.py fence-agents-4.0.24/fence/agents/vbox/fence_vbox.py
+--- fence-agents-4.0.24-orig/fence/agents/vbox/fence_vbox.py	2016-08-22 08:33:34.000000000 -0400
++++ fence-agents-4.0.24/fence/agents/vbox/fence_vbox.py	2017-09-11 11:46:40.000000000 -0400
+@@ -31,7 +31,7 @@
+ def _invoke(conn, options, *cmd):
+     prefix = options["--sudo-path"] + " " if "--use-sudo" in options else ""
+     conn.sendline(prefix + "VBoxManage " + " ".join(cmd))
+-    conn.log_expect(options["--command-prompt"], int(options["--shell-timeout"]))
++    conn.log_expect({}, options["--command-prompt"], int(options["--shell-timeout"]))
+ 
+ 
+ def get_outlets_status(conn, options):

--- a/fence-agents-vbox/fence-agents-vbox.spec
+++ b/fence-agents-vbox/fence-agents-vbox.spec
@@ -15,7 +15,7 @@ Summary: Fence agent for VirtualBox
 Requires: openssh-clients
 Requires: fence-agents-common
 Version: 4.0.24
-Release: 2%{?alphatag:.%{alphatag}}%{?dist}
+Release: 3%{?alphatag:.%{alphatag}}%{?dist}
 License: GPLv2+ and LGPLv2+
 Group: System Environment/Base
 URL: http://sourceware.org/cluster/wiki/
@@ -68,5 +68,8 @@ rm -rf %{buildroot}
 ccs_update_schema > /dev/null 2>&1 ||:
 
 %changelog
+* Mon Sep 11 2017 Joe Grund <joe.grund@intel.com> - 4.0.24-3
+- Patch source to be compatible with older fence-agents-all.
+
 * Fri Aug 11 2017 Joe Grund <joe.grund@intel.com> - 4.0.24-2
-- Extract fence-agents-vbox to standalone rpm
+- Extract fence-agents-vbox to standalone rpm.

--- a/fence-agents-vbox/fence-agents-vbox.spec
+++ b/fence-agents-vbox/fence-agents-vbox.spec
@@ -20,6 +20,7 @@ License: GPLv2+ and LGPLv2+
 Group: System Environment/Base
 URL: http://sourceware.org/cluster/wiki/
 Source0: https://fedorahosted.org/releases/f/e/fence-agents/fence-agents-%{version}.tar.xz
+Patch1: fence-agents-%{version}.patch
 
 ## Setup/build bits
 


### PR DESCRIPTION
There is an incompatibility between the version of fence_vbox we are packaging, and the fence-agents-all currently supllied in CentOS. 

Patch the fence_vbox source to make it compatible.